### PR TITLE
changing the download links to point to Phoebus

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -104,7 +104,7 @@ const DownloadSubtext = styled.p`
 const DownloadButton = ({ link, os }) => (
   <div>
     <StyledDownloadButton href={link}>
-      <FontAwesomeIcon icon={faDownload} /> Download Control System Studio
+      <FontAwesomeIcon icon={faDownload} /> Download Phoebus
     </StyledDownloadButton>
     <DownloadSubtext>
       Version {dlInfo.downloadVersion} for {os} |{" "}
@@ -116,7 +116,7 @@ const DownloadButton = ({ link, os }) => (
 const DevDownloadButton = () => (
   <div>
     <StyledDownloadButtonDev href={dlInfo.downloadDev}>
-      <FontAwesomeIcon icon={faDownload} /> Download Development Build
+      <FontAwesomeIcon icon={faDownload} /> Download Phoebus Development Build
     </StyledDownloadButtonDev>
     <DownloadSubtext>Version {dlInfo.downloadDevVersion}</DownloadSubtext>
   </div>
@@ -175,7 +175,6 @@ const Download = () => {
               os={"Windows"}
             />
           )}
-          <DevDownloadButton />
         </Flex>
         <h2>Site Specific Versions</h2>
         <SiteSpecificVersions />

--- a/src/utils/downloadinfo.js
+++ b/src/utils/downloadinfo.js
@@ -1,9 +1,9 @@
 export const dlInfo = {
-    downloadVersion: "4.5.9",
-    downloadStableLinux: "http://download.controlsystemstudio.org/release/4.5/cs-studio-4.5.9-linux.gtk.x86_64.tar.gz",
-    downloadStableWindows: "http://download.controlsystemstudio.org/release/4.5/cs-studio-4.5.9-win32.win32.x86_64.zip",
-    downloadStableMac: "http://download.controlsystemstudio.org/release/4.5/cs-studio-4.5.9-macosx.cocoa.x86_64.zip",
-    allDownloads: "http://download.controlsystemstudio.org/release/4.5/",
+    downloadVersion: "4.7.2",
+    downloadStableLinux: "https://github.com/ControlSystemStudio/phoebus/releases/download/v4.7.2/phoebus-4.7.2-linux.tar.gz",
+    downloadStableWindows: "https://github.com/ControlSystemStudio/phoebus/releases/download/v4.7.2/phoebus-4.7.2-win.zip",
+    downloadStableMac: "https://github.com/ControlSystemStudio/phoebus/releases/download/v4.7.2/phoebus-4.7.2-macos.tar.gz",
+    allDownloads: "https://github.com/ControlSystemStudio/phoebus/releases",
     downloadDevVersion: "4.6.0",
     downloadDev: "https://openepics.ci.cloudbees.com/view/CS-Studio%204.6/",
 }


### PR DESCRIPTION
removing the references to the now non functional downloads.controlsystemstudio.org ( it would still be good to know who was hosting that )

This is just the first step while we figure out how to automatically publish on github and find a solution for the nightly common builds
